### PR TITLE
fix(docker-build): add locale with utf8 env variable for buildroot user

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -3,8 +3,10 @@ RUN apt update && \
     apt install -y build-essential \
     git gcc wget curl musl-dev file locales \
     perl python rsync bc patch unzip cpio
-RUN locale-gen en_US.UTF-8 && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+    locale-gen en_US.UTF-8 && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 RUN adduser --gecos "Buildroot" --disabled-login --uid 1000 buildroot && \
     mkdir -p /home/buildroot && chown buildroot:buildroot /home/buildroot
 USER buildroot
+ENV LANG en_US.UTF-8
 WORKDIR /home/buildroot


### PR DESCRIPTION
And run `localedef` as suggested @ https://hub.docker.com/_/ubuntu/ (dunno if it duplicates d2f9109)