### PR TITLE
Make persist-resize.service faster on pcDuino3

### DIFF
--- a/configs/pcduino/3/resources/gen-image/genimage.cfg
+++ b/configs/pcduino/3/resources/gen-image/genimage.cfg
@@ -14,6 +14,8 @@ image boot.vfat {
 
 image rootfs.ext4 {
 	ext4 {
+		use-mke2fs = true
+		extraargs = "-O ^64bit,^metadata_csum,resize_inode,sparse_super"
 		label = rootfs
 	}
 
@@ -23,6 +25,8 @@ image rootfs.ext4 {
 
 image persist.ext4 {
 	ext4 {
+		use-mke2fs = true
+		extraargs = "-O ^64bit,^metadata_csum,resize_inode,sparse_super"
 		label = persist
 	}
 

--- a/configs/pcduino/3/scripts/format_sd.sh
+++ b/configs/pcduino/3/scripts/format_sd.sh
@@ -40,7 +40,7 @@ if [ -z "$SKIFF_NO_INTERACTIVE" ]; then
   fi
 fi
 
-MKEXT4="mkfs.ext4 -F -O ^64bit"
+MKEXT4="mkfs.ext4 -F -O ^64bit,^metadata_csum,resize_inode,sparse_super"
 
 echo "Formatting device..."
 parted "$PCDUINO_SD" mklabel msdos

--- a/scripts/build_configs.sh
+++ b/scripts/build_configs.sh
@@ -87,7 +87,7 @@ touch $users_conf
 
 # Make the scripts wrappers
 bind_env="$(env | grep 'SKIFF_*' | sed 's/^/export /' | sed 's/=/=\"/' | sed 's/$/\"/')"
-bind_path_env="export PATH=\"\${PATH}:${BUILDROOT_DIR}/output/host/usr/bin:${BUILDROOT_DIR}/output/host/usr/sbin\""
+bind_path_env="export PATH=$BUILDROOT_DIR/output/host/bin:$BUILDROOT_DIR/output/host/sbin:\$PATH"
 bind_env_script=$SKIFF_FINAL_CONFIG_DIR/bind_env.sh
 pre_build_script=$SKIFF_FINAL_CONFIG_DIR/pre_build.sh
 post_build_script=$SKIFF_FINAL_CONFIG_DIR/post_build.sh


### PR DESCRIPTION
Before:

```
# dmesg | grep SkiffOS
[   13.288240] systemd[1]: Starting SkiffOS resize persist partition...
[  433.415545] systemd[1]: Started SkiffOS resize persist partition.
```

After:

```
# dmesg | grep SkiffOS
[   13.181004] systemd[1]: Starting SkiffOS resize persist partition...
[   93.163695] systemd[1]: Started SkiffOS resize persist partition.
```