### PR TITLE
Build in Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ buildroot-work/
 *.org_archive
 .#*
 *.swp
+.vagrant/
+*.log

--- a/vagrant-build/Vagrantfile
+++ b/vagrant-build/Vagrantfile
@@ -1,0 +1,29 @@
+Vagrant.configure(2) do |config|
+  config.vagrant.plugins = "vagrant-disksize"
+
+  config.vm.box = "ubuntu/bionic64"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+  end
+
+  config.disksize.size = "20GB"
+
+  config.vm.synced_folder "..", "/vagrant"
+
+  config.vm.provision "shell", inline: $script, privileged: false
+
+  config.vm.provision "shell", run: "always" do |s|
+    s.inline = "sudo mount -B ~/workspaces /vagrant/workspaces"
+    s.privileged = false
+  end
+
+  config.ssh.extra_args = ["-t", "cd /vagrant; bash -l"]
+end
+
+$script = <<SCRIPT
+sudo apt update
+sudo apt install -y cmake g++ make mtools python unzip
+
+install -D -m 644 /vagrant/workspaces/.gitignore ~/workspaces/.gitignore
+SCRIPT


### PR DESCRIPTION
Vagrant provides easy to configure, reproducible, and portable work environments.

---

Make sure that [Vagrant](https://www.vagrantup.com/downloads.html) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads) are installed before the following steps are performed.

1. Set the environment variable (**needless** in `vagrant-build`)

PowerShell

```
> $env:VAGRANT_CWD = "vagrant-build"
```

Cmd

```
> set VAGRANT_CWD=vagrant-build
```

Bash

```
$ export VAGRANT_CWD=vagrant-build
```

2. Boot the Vagrant box

```
> vagrant up
```

3. Enter the Vagrant box

```
> vagrant ssh
```

4. Build a SkiffOS image

```
$ make SKIFF_CONFIG=pcduino/3,apps/docker,apps/ttyd configure
$ make compile
$ make cmd/pcduino/3/buildimage
$ cp workspaces/default/output/images/sdcard.img /vagrant/
```

5. Exit the Vagrant box

```
$ logout
```

6. Halt the Vagrant box

```
> vagrant halt
```